### PR TITLE
feat: support wildcard matching for domains and IPs in whitelist

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -7,6 +7,8 @@
 
 bool wildcard_match(char const *needle, char const *haystack);
 
+bool wildcard_match_iterative(const std::string &pattern, const std::string &str);
+
 bool check_host_name(const char *pattern, size_t pattern_len, std::string host);
 
 std::string last_n_chars(const std::string &input, unsigned int n);

--- a/utils.cpp
+++ b/utils.cpp
@@ -41,6 +41,32 @@ bool wildcard_match(char const *needle, char const *haystack) {
     return *haystack == '\0';
 }
 
+bool wildcard_match_iterative(const std::string &pattern, const std::string &str) {
+    size_t p = 0, s = 0;
+    size_t star = std::string::npos, ss = 0;
+
+    while (s < str.size()) {
+        if (p < pattern.size() && (pattern[p] == str[s] || pattern[p] == '?')) {
+            p++;
+            s++;
+        } else if (p < pattern.size() && pattern[p] == '*') {
+            star = p++;
+            ss = s;
+        } else if (star != std::string::npos) {
+            p = star + 1;
+            s = ++ss;
+        } else {
+            return false;
+        }
+    }
+
+    while (p < pattern.size() && pattern[p] == '*') {
+        p++;
+    }
+
+    return p == pattern.size();
+}
+
 bool is_space_or_tab(char c) { return c == ' ' || c == '\t'; }
 
 std::pair<size_t, size_t> trim(const char *b, const char *e, size_t left,
@@ -252,11 +278,33 @@ int tcp_get_auto_ttl(const uint8_t ttl, const uint8_t autottl1,
 }
 
 bool match_whitelist_domain(const std::string &domain) {
-    return Settings_perst.whitelist_domains.find(domain) != Settings_perst.whitelist_domains.end();
+    if (Settings_perst.whitelist_domains.find(domain) != Settings_perst.whitelist_domains.end()) {
+        return true;
+    }
+
+    for (const auto &pattern : Settings_perst.whitelist_domains) {
+        if ((pattern.find('*') != std::string::npos || pattern.find('?') != std::string::npos) &&
+            wildcard_match_iterative(pattern, domain)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 bool match_whitelist_ip(const std::string &ip) {
-    return Settings_perst.whitelist_ips.find(ip) != Settings_perst.whitelist_ips.end();
+    if (Settings_perst.whitelist_ips.find(ip) != Settings_perst.whitelist_ips.end()) {
+        return true;
+    }
+
+    for (const auto &pattern : Settings_perst.whitelist_ips) {
+        if ((pattern.find('*') != std::string::npos || pattern.find('?') != std::string::npos) &&
+            wildcard_match_iterative(pattern, ip)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 int load_whitelist() {


### PR DESCRIPTION
**Description**
This pull request adds support for wildcard matching when specifying domains and IP addresses in the whitelist. This improvement allows for more flexible and efficient configurations.

```shell
# Examples

# Whitelisted domains
example1.com
*example2.com
example3.*
sub.*.*
*.example5.*

# Whitelisted ip addresses
192.168.*.*
10.0.0.?

# Domain tests
example1.com -> EXACT MATCH
example2.com -> MATCH with pattern: *example2.com
2example2.com -> MATCH with pattern: *example2.com
sub.example2.com -> MATCH with pattern: *example2.com
example3.com -> MATCH with pattern: example3.*
example3.net -> MATCH with pattern: example3.*
example3.net.tr -> MATCH with pattern: example3.*
sub.example.com -> MATCH with pattern: sub.*.*
foo.example5.net -> MATCH with pattern: *.example5.*
google.com -> NO MATCH

# IP Tests
192.168.0.1 -> MATCH with pattern: 192.168.*.*
192.168.100.200 -> MATCH with pattern: 192.168.*.*
10.0.0.5 -> MATCH with pattern: 10.0.0.?
10.0.0.12 -> NO MATCH
172.16.0.1 -> NO MATCH
```

**Related Issues**
(No related issues listed)

**Changes Made**
- Added logic for handling wildcard entries within the whitelist.